### PR TITLE
Fix buzzer frequency at initialization

### DIFF
--- a/C/Sketches/Sketch_07.2_Aleror/Sketch_07.2_Aleror.ino
+++ b/C/Sketches/Sketch_07.2_Aleror/Sketch_07.2_Aleror.ino
@@ -7,12 +7,13 @@
 #define PIN_BUZZER 14
 #define PIN_BUTTON 21
 #define CHN        0   //define the pwm channel
+#define MAX_FREQ   2000
 
 void setup() {
   pinMode(PIN_BUTTON, INPUT);
   pinMode(PIN_BUZZER, OUTPUT);
-  ledcAttachChannel(PIN_BUZZER, 1, 10, CHN);  //attach the led pin to pwm channel
-  ledcWriteTone(PIN_BUZZER, 2000);        //Sound at 2KHz for 0.3 seconds
+  ledcAttachChannel(PIN_BUZZER, MAX_FREQ, 10, CHN);  //attach the led pin to pwm channel
+  ledcWriteTone(PIN_BUZZER, MAX_FREQ);        //Sound at 2KHz for 0.3 seconds
   delay(300);
 }
 
@@ -29,7 +30,7 @@ void alert() {
   int toneVal;          // Define a variable to save sound frequency
   for (int x = 0; x < 360; x += 10) {     // X from 0 degree->360 degree
     sinVal = sin(x * (PI / 180));       // Calculate the sine of x
-    toneVal = 2000 + sinVal * 500;      // Calculate sound frequency according to the sine of x
+    toneVal = MAX_FREQ + sinVal * 500;      // Calculate sound frequency according to the sine of x
     ledcWriteTone(PIN_BUZZER, toneVal);
     delay(10);
   }


### PR DESCRIPTION
Fix an issue with ledcAttachChannel initialization.
Initializing it to anything bellow 100 does not allow the buzzer to sound with appropriate loudness/volume.
Initial frequency must be initialized to something close to max frequency you're planning to use.

Was very frustrated why this sample didn't work.
Save beginners from this misery 😊.

VS Code 1.103.2
PIOArduino 1.1.0
espressif Arduino 3.3.0 and IDF 5.5.0

The same happens with Arduino Studio.